### PR TITLE
Client#refresh_token! returns the response hash

### DIFF
--- a/lib/google-contacts/client.rb
+++ b/lib/google-contacts/client.rb
@@ -58,7 +58,7 @@ module GContacts
     # @param [String] refresh_token which was originally passed to the user on login
     #
     # @raise [Net::HTTPError]
-    #
+    # @return [Hash] the refreshed access token hash
     def refresh_token!(client_id, client_secret, refresh_token)
       uri = API_URI[:oauth]
       raise ArgumentError, "Unsupported type given" unless uri
@@ -69,6 +69,7 @@ module GContacts
 
       @options[:access_token] = token["access_token"]
       @options[:expires_at] = DateTime.now + Rational(token["expires_in"].to_i, 86400)
+      token
     end
 
     ##

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -26,7 +26,11 @@ describe GContacts::Client do
       end
 
       client = GContacts::Client.new(:access_token => "12341234")
-      client.refresh_token! "client_id", "client_secret", "refresh_token"
+      token_hash = {
+        'access_token' => 'refreshed_token',
+        'expires_in'   => 3600,
+        'token_type'   => 'Bearer' }
+      client.refresh_token!("client_id", "client_secret", "refresh_token").should == token_hash
       client.options[:access_token].should == "refreshed_token"
       client.options[:expires_at].should >= DateTime.now
     end


### PR DESCRIPTION
Returning the response hash makes it a little easier to update your database with the updated access token. It's possible to do this current by pulling the access token from `client.options[:access_token]`, but relying on the return value felt a little more natural.
