### PR TITLE
Relax nokogiri dependency.

### DIFF
--- a/google-contacts.gemspec
+++ b/google-contacts.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "google-contacts"
 
-  s.add_runtime_dependency "nokogiri", "~>1.5.0"
+  s.add_runtime_dependency "nokogiri", "~>1.6"
   s.add_runtime_dependency "nori", "~>2.2"
 
   s.add_runtime_dependency "jruby-openssl", "~>0.7.0" if RUBY_PLATFORM == "java"


### PR DESCRIPTION
Main motivation for this is that recent versions of Rails (e.g. 4.2.x) require nokogiri ~> 1.6.0
